### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -18,6 +18,10 @@
 
 name: "Microsoft Defender For Devops"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/michalherbut2/siemaktopl/security/code-scanning/6](https://github.com/michalherbut2/siemaktopl/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is required for `actions/checkout` to read the repository's contents.
- `security-events: write` is required for `github/codeql-action/upload-sarif` to upload SARIF files to the Security tab.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `MSDO` job to limit permissions to that specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
